### PR TITLE
Uses curv tagged with v0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde_derive = "1.0"
 serde = "1.0"
 #rayon = "1.0.3"
 #curv = { package = "curv-kzen", version = "0.7", default-features = false }
-curv = { git = "https://github.com/Polkadex-Substrate/curv.git", default-features = false, version = "0.7" }
+curv = { git = "https://github.com/Polkadex-Substrate/curv.git", default-features = false, tag = "v0.7.1" }
 
 [dependencies.bulletproof]
 git = "https://github.com/Polkadex-Substrate/bulletproofs"


### PR DESCRIPTION
Updates the `curv` dependency due to yanked crypto-mac dependency problem.
